### PR TITLE
fix broken test for 'fast' mode

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
 var semver = require("semver");
-var currentWorkingDirectory = path.basename(process.cwd());
+var currentWorkingDirectory;
 var wiredep = require('wiredep');
 var yosay = require('yosay');
 var GruntfileEditor = require('gruntfile-editor');
@@ -37,7 +37,7 @@ var final = '\n\nYour angular project has been successfully generated.' +
 var NgtailorGenerator = yeoman.generators.Base.extend({
 
     init: function () {
-
+    	currentWorkingDirectory = path.basename(process.cwd());
 		this.name = currentWorkingDirectory;
         this.angular_version = '*';
         this.version = '0.0.1';

--- a/test/test-mode-fast.js
+++ b/test/test-mode-fast.js
@@ -19,7 +19,7 @@ describe('fast', function () {
 			});
 
 		done();
-		
+
 	});
 
 	it('creates expected files', function (done) {
@@ -64,7 +64,7 @@ describe('fast', function () {
 
 		gen.onEnd(function() {
 
-			assert.fileContent('package.json', /"name": "generator-ngtailor"/);
+			assert.fileContent('package.json', /"name": "fast"/);
 			assert.fileContent('package.json', /"version": "0\.0\.1"/);
 
 			assert.fileContent('package.json', /grunt-usemin/);
@@ -156,7 +156,7 @@ describe('fast', function () {
 	it("app.js content", function (done) {
 
 		gen.onEnd(function() {
-			assert.fileContent('app/js/app.js', /angular\.module\('generator-ngtailor'/);
+			assert.fileContent('app/js/app.js', /angular\.module\('fast'/);
 			assert.noFileContent('app/js/app.js', /angular\.module\('MyApp'\)\.config\(function\(\$stateProvider, \$urlRouterProvider, \$translateProvider/);
 			done();
 		});


### PR DESCRIPTION
`npm test` fails currently. below is log from [Travis CI](https://travis-ci.org/lauterry/generator-ngtailor#L1562)

``` bash
  1) fast package.json content:
     Uncaught AssertionError: package.json did not match '/"name": "generator-ngtailor"/'.
      at /home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/test/assert.js:146:12
      at Array.forEach (native)
      at Function.assert.fileContent (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/test/assert.js:141:9)
      at RunContext.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/test/test-mode-fast.js:67:11)
      at RunContext.emit (events.js:92:17)
      at g (events.js:180:16)
      at emit (events.js:117:20)
      at null.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/base.js:364:10)
      at null.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/base.js:372:5)
      at Queue.g (events.js:180:16)
      at Queue.emit (events.js:92:17)
      at Queue.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:68:12)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:79:43)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at Queue._exec (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:83:3)
      at null.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/base.js:428:7)
      at Conflicter.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/util/conflicter.js:70:5)
      at /home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/async/lib/async.js:254:17
      at /home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/async/lib/async.js:157:25
      at /home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/async/lib/async.js:251:21
      at Object.callback (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/async/lib/async.js:615:34)
      at null.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/base.js:656:21)
      at processImmediate [as _immediateCallback] (timers.js:345:15)
  2) fast app.js content:
     Uncaught AssertionError: app/js/app.js did not match '/angular\.module\('generator-ngtailor'/'.
      at /home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/test/assert.js:146:12
      at Array.forEach (native)
      at Function.assert.fileContent (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/test/assert.js:141:9)
      at RunContext.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/test/test-mode-fast.js:159:11)
      at RunContext.emit (events.js:92:17)
      at g (events.js:180:16)
      at emit (events.js:117:20)
      at null.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/base.js:364:10)
      at null.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/base.js:372:5)
      at Queue.g (events.js:180:16)
      at Queue.emit (events.js:92:17)
      at Queue.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:68:12)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:79:43)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at SubQueue.run (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/subqueue.js:41:45)
      at Queue.next (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:80:39)
      at Queue._exec (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/grouped-queue/lib/queue.js:83:3)
      at null.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/base.js:428:7)
      at Conflicter.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/util/conflicter.js:70:5)
      at /home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/async/lib/async.js:254:17
      at /home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/async/lib/async.js:157:25
      at /home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/async/lib/async.js:251:21
      at Object.callback (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/node_modules/async/lib/async.js:615:34)
      at null.<anonymous> (/home/travis/build/lauterry/generator-ngtailor/node_modules/yeoman-generator/lib/base.js:656:21)
      at processImmediate [as _immediateCallback] (timers.js:345:15)
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
The command "npm test" exited with 1.
```

this PR is for fixing this problem:smile:
